### PR TITLE
Add doc about JS assets build in Migration guide

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -500,6 +500,8 @@ assets must be built for PRODUCTION.
 
 Run `$ npm run build` to build assets for PRODUCTION.
 
+> If you need to see instant changes/build on files, use the following command: `$ npm run watch`
+
 ### Troubleshooting
 
 > if `npm install` fails with error: `Failed at the ... postinstall script.`


### PR DESCRIPTION
Add documentation about JS assets building. Mainly the required npm commands for frontend noobs like me.